### PR TITLE
Fixed BUG when running in Solaris x86 and Solaris SPARC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 blast-dbf: blast-dbf.c blast.c blast.h
-	gcc -o blast-dbf blast.c blast-dbf.c
+	cc -o blast-dbf blast.c blast-dbf.c
 
 test: blast-dbf
 	./blast-dbf < sids.dbc | cmp - sids.dbf

--- a/blast-dbf.c
+++ b/blast-dbf.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include "blast.h"
 
@@ -46,12 +47,18 @@ static int outf(void *how, unsigned char *buf, unsigned len)
     This function handles the processing of input to output given both file descriptors.
  */
 int dbc2dbf(FILE* input, FILE* output) {
-    int     read, err, header, ret, n;
+    int           read = 0, err = 0, ret = 0, n = 0;
+    uint16_t      header = 0;
+    unsigned char rawHeader[2];
 
     read = fseek(input, 8, SEEK_SET);
     err = ferror(input);
-    read = fread(&header, 2, 1, input);
+
+    read = fread(rawHeader, 2, 1, input);
     err = ferror(input);
+
+    /* Platform independent code (header is stored in little endian format) */
+    header = rawHeader[0] + (rawHeader[1] << 8);
 
     read = fseek(input, 0, SEEK_SET);
     err = ferror(input);


### PR DESCRIPTION
The original code read the header size as integer (32 or 64 bits depending on the platform), but the header size is a 16 bit integer, resulting in segmentation faults / core dumps in Solaris (x86 and SPARC).

Also the original code didn't account for endianess differences between platforms. The header size is stored in little endian format, hence it was compatible with x86, but platforms like Solaris SPARC are big endian and would treat the header size incorrectly.

Both issues were fixed in this pull request.
