### PR TITLE
Fixed bug where the header doesn't end with 0x0D

### DIFF
--- a/blast-dbf.c
+++ b/blast-dbf.c
@@ -67,6 +67,7 @@ int dbc2dbf(FILE* input, FILE* output) {
 
     read = fread(buf, 1, header, input);
     err = ferror(input);
+    buf[header-1] = 0x0D;
     read = fwrite(buf, 1, header, output);
     err = ferror(output);
 


### PR DESCRIPTION
Some `.dbc` files, when converted to `.dbf` lack the `0x0D` flag at the end of the header, which in turn makes some software misbehave, for instance: `dbfread` lib in Python, LibreOffice Calc, MS Excel.

The fix implemented just sets explicitly the value `0x0D` in the last byte of the header buffer.