### PR TITLE
Fix out-of-bounds write 

### DIFF
--- a/blast-dbf.c
+++ b/blast-dbf.c
@@ -63,6 +63,7 @@ int dbc2dbf(FILE* input, FILE* output) {
     read = fseek(input, 0, SEEK_SET);
     err = ferror(input);
 
+    if( header-1 < 0) return -4;
     unsigned char buf[header];
 
     read = fread(buf, 1, header, input);


### PR DESCRIPTION
(In reference to https://github.com/eaglebh/blast-dbf/issues/6)

Using error code `-4` since `-1, -2, -3` are reserved by the original `blast.c` implementation.